### PR TITLE
Simplify getImageData function for better readability

### DIFF
--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -261,10 +261,12 @@ class Event
      */
     public function getImageData(): array
     {
+        if (!$this->image) {
+            return null;
+        }
+        
         return [
-            'id' => ($image = $this->image)
-                ? $image->getId()
-                : null,
+            'id' => $this->image->getId(),
         ];
     }
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -264,7 +264,7 @@ class Event
         if (!$this->image) {
             return null;
         }
-        
+
         return [
             'id' => $this->image->getId(),
         ];

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -254,12 +254,12 @@ class Event
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, mixed>|null
      *
      * @Serializer\VirtualProperty
      * @Serializer\SerializedName("image")
      */
-    public function getImageData(): array
+    public function getImageData(): ?array
     {
         if (!$this->image) {
             return null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Simplify getImageData function for better readability.

#### Why?

The current code is hard to understand so instead of a short if end else i use a real if else statement to and don't write $image into an own variable. Think this make it a lot easier to read and show what should happen.
